### PR TITLE
docs: document rpm_status_leds_interval ID for config overrides

### DIFF
--- a/site/src/content/docs/reference/modules/rpm-status-leds.md
+++ b/site/src/content/docs/reference/modules/rpm-status-leds.md
@@ -33,6 +33,8 @@ The module reads the RPM sensor for each fan every 10 seconds and maps the value
 
 LED brightness is set to 50%. The module writes directly to the `fan1_led` through `fan4_led` partition light entities defined in the Rev 3.x hardware packages.
 
+The interval component is exposed as `rpm_status_leds_interval`, allowing you to override it in your own config (e.g., to change the update frequency).
+
 ## Home Assistant Entities
 
 This module creates **no additional Home Assistant entities**. It writes directly to the existing LED partition light entities (`fan1_led` through `fan4_led`) that are already exposed by the Rev 3.x hardware package.
@@ -65,6 +67,23 @@ packages:
       - path: modules/rpm_status_leds.yaml
         vars:
           full_rpm: "1500"
+```
+
+### Changing the Update Interval
+
+The interval defaults to 10 seconds. Override `rpm_status_leds_interval` to change the frequency:
+
+```yaml
+packages:
+  rpm_status_leds:
+    url: https://github.com/zeroflow/wifi-fancontroller
+    ref: main
+    files:
+      - path: modules/rpm_status_leds.yaml
+
+interval:
+  - id: rpm_status_leds_interval
+    interval: 5s
 ```
 
 ## Tuning Tips

--- a/static/index.md
+++ b/static/index.md
@@ -123,7 +123,7 @@ The fan controller firmware is built around reusable ESPHome packages. Drop any 
 | <i class="fa-solid fa-chart-line"></i> **Temperature Curve** | `modules/temperature_curve.yaml` | Up to 5 configurable temperature/speed points with linear interpolation. Points are editable from Home Assistant and auto-sorted at runtime. |
 | <i class="fa-solid fa-temperature-half"></i> **Temperature Linear** | `modules/temperature_linear.yaml` | Simple three-zone control: off below a threshold, constant minimum speed, then linear ramp to full speed. |
 | <i class="fa-solid fa-gauge-high"></i> **RPM PI Control** | `modules/rpm_pi_control.yaml` | Holds each fan at a target RPM using a PI controller. Includes anti-windup, deadband, and per-fan debug sensors. |
-| <i class="fa-solid fa-circle-dot"></i> **RPM Status LEDs** | `modules/rpm_status_leds.yaml` | Colors each fan's RGB LED from red (stopped) to green (full speed) based on live RPM. Configurable max RPM scale. |
+| <i class="fa-solid fa-circle-dot"></i> **RPM Status LEDs** | `modules/rpm_status_leds.yaml` | Colors each fan's RGB LED from red (stopped) to green (full speed) based on live RPM. Configurable max RPM scale. The update interval is exposed as `rpm_status_leds_interval` for ESPHome config overrides. |
 
 ### Usage Example
 


### PR DESCRIPTION
## Summary

- Documents the `rpm_status_leds_interval` ID added to the RPM Status LEDs module, allowing users to override the update interval in their own ESPHome config
- Updates the module table in `static/index.md`
- Adds a note and override YAML example to the Starlight reference page

## Test plan

- [ ] Verify the Starlight docs page renders correctly
- [ ] Verify the Jekyll index page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)